### PR TITLE
fix: ensure tracking maxInclusive and minInclusive for numbers and bigints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ options:
 ## Roadmap
 
 - deserialization (WIP lives on branch [dezerial](https://github.com/commonbaseapp/zodex/tree/dezerial), could use some help from TypeScript heroes)
-- missing checks
-  - **number:** gte, lte, positive, nonnegative, negative, nonpositive
-  - **bigInt:** same as number
 - custom error messages are not included
 
 ## Caveats

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -87,6 +87,61 @@ test.each([
       min: 23,
       max: 42,
       multipleOf: 5,
+      minInclusive: true,
+      maxInclusive: true,
+    },
+  ],
+
+  [
+    s(z.number().gt(14).lt(20)),
+    {
+      type: "number",
+      min: 14,
+      max: 20,
+    },
+  ],
+
+  [
+    s(z.number().gte(14).lte(20)),
+    {
+      type: "number",
+      min: 14,
+      minInclusive: true,
+      max: 20,
+      maxInclusive: true,
+    },
+  ],
+
+  [
+    s(z.number().positive()),
+    {
+      type: "number",
+      min: 0,
+    },
+  ],
+  [
+    s(z.number().negative()),
+    {
+      type: "number",
+      max: 0,
+    },
+  ],
+
+  [
+    s(z.number().nonnegative()),
+    {
+      type: "number",
+      min: 0,
+      minInclusive: true,
+    },
+  ],
+
+  [
+    s(z.number().nonpositive()),
+    {
+      type: "number",
+      max: 0,
+      maxInclusive: true,
     },
   ],
 
@@ -96,6 +151,8 @@ test.each([
       type: "number",
       min: -9007199254740991,
       max: 9007199254740991,
+      minInclusive: true,
+      maxInclusive: true,
     },
   ],
 
@@ -120,8 +177,63 @@ test.each([
     {
       type: "bigInt",
       min: 23n,
+      minInclusive: true,
       max: 42n,
+      maxInclusive: true,
       multipleOf: 5n,
+    },
+  ],
+
+  [
+    s(z.bigint().gt(14n).lt(20n)),
+    {
+      type: "bigInt",
+      min: 14n,
+      max: 20n,
+    },
+  ],
+
+  [
+    s(z.bigint().gte(14n).lte(20n)),
+    {
+      type: "bigInt",
+      min: 14n,
+      minInclusive: true,
+      max: 20n,
+      maxInclusive: true,
+    },
+  ],
+
+  [
+    s(z.bigint().positive()),
+    {
+      type: "bigInt",
+      min: 0n,
+    },
+  ],
+  [
+    s(z.bigint().negative()),
+    {
+      type: "bigInt",
+      max: 0n,
+    },
+  ],
+
+  [
+    s(z.bigint().nonnegative()),
+    {
+      type: "bigInt",
+      min: 0n,
+      minInclusive: true,
+    },
+  ],
+
+  [
+    s(z.bigint().nonpositive()),
+    {
+      type: "bigInt",
+      max: 0n,
+      maxInclusive: true,
     },
   ],
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export type SzNumber = {
   type: "number";
   min?: number;
   max?: number;
+  minInclusive?: number;
+  maxInclusive?: number;
   multipleOf?: number;
   int?: true;
   finite?: true;
@@ -14,6 +16,8 @@ export type SzBigInt = {
   type: "bigInt";
   min?: bigint;
   max?: bigint;
+  minInclusive?: number;
+  maxInclusive?: number;
   multipleOf?: bigint;
 };
 export type SzString = {

--- a/src/zerialize.ts
+++ b/src/zerialize.ts
@@ -149,9 +149,15 @@ const zerializers = {
       (o, check) => ({
         ...o,
         ...(check.kind == "min"
-          ? { min: check.value }
+          ? {
+              min: check.value,
+              ...(check.inclusive ? { minInclusive: true } : {}),
+            }
           : check.kind == "max"
-          ? { max: check.value }
+          ? {
+              max: check.value,
+              ...(check.inclusive ? { maxInclusive: true } : {}),
+            }
           : check.kind == "multipleOf"
           ? { multipleOf: check.value }
           : check.kind == "int"
@@ -210,9 +216,15 @@ const zerializers = {
       (o, check) => ({
         ...o,
         ...(check.kind == "min"
-          ? { min: check.value }
+          ? {
+              min: check.value,
+              ...(check.inclusive ? { minInclusive: true } : {}),
+            }
           : check.kind == "max"
-          ? { max: check.value }
+          ? {
+              max: check.value,
+              ...(check.inclusive ? { maxInclusive: true } : {}),
+            }
           : check.kind == "multipleOf"
           ? { multipleOf: check.value }
           : {}),


### PR DESCRIPTION
BREAKING CHANGE:

Now builds `maxInclusive` and `minInclusive` if encoded by Zod

