### PR TITLE
feat: superRefinements, transforms, preprocesses options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,26 @@ options:
         value: "b"
 ```
 
+## Options
+
+Both `zerialize` and `dezerialize` accept an options object with the same properties.
+
+Since Zod does not allow the specification of the names of effects (refinements, transforms, and preprocesses), we allow you to supply as options maps of names to effects so that these can be part of serialization and deserialization. Note that due to technical limitations, we cannot support the regular `refine()` method (and it will be ignored) but `superRefine()` is supported. If none of these options are supplied,
+the effects will be omitted.
+
+Properties:
+
+- `superRefinements` - Map of name to `.superRefine()` functions
+- `transforms` - Map of name to `.transform()` functions
+- `preprocesses` - Map of name to `z.preprocess()` functions
+
 ## Roadmap
 
 - custom error messages are not included
 
 ## Caveats
 
-- lazy, effects and brand are omitted
+- lazy and brand are omitted
 - pipeline and catch types are unwrapped
 - native enums are turned into enums
 - recursive schemas not currently supported

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "husky install",
     "check-style": "prettier --check src",
     "lint": "eslint src/**",
-    "test": "vitest --coverage",
+    "test": "vitest --coverage --silent=false",
     "build": "rm -rf dist && pnpm tsc",
     "prepublish": "pnpm run build"
   },

--- a/src/dezerialize.ts
+++ b/src/dezerialize.ts
@@ -34,9 +34,18 @@ import {
 import { ZodTypes } from "./zod-types";
 
 type DezerializerOptions = {
-  superRefinements?: { [key: string]: (value: any, ctx: any) => void };
-  transforms?: { [key: string]: (value: any, ctx: any) => void };
-  preprocesses?: { [key: string]: (value: any, ctx: any) => void };
+  superRefinements?: {
+    [key: string]: (value: any, ctx: z.RefinementCtx) => Promise<void> | void;
+  };
+  transforms?: {
+    [key: string]: (
+      value: any,
+      ctx: z.RefinementCtx
+    ) => Promise<unknown> | unknown;
+  };
+  preprocesses?: {
+    [key: string]: (value: any, ctx: z.RefinementCtx) => unknown;
+  };
 };
 
 type DistributiveOmit<T, K extends keyof any> = T extends any

--- a/src/dezerialize.ts
+++ b/src/dezerialize.ts
@@ -208,7 +208,7 @@ const dezerializers = {
   literal: (shape) => z.literal(shape.value),
 
   tuple: ((shape: SzTuple) => {
-    let i = z.tuple(shape.items.map(dezerialize) as any);
+    let i = z.tuple(shape.items.map((item) => dezerialize(item)) as any);
     if (shape.rest) {
       i = i.rest(dezerialize(shape.rest) as any);
     }
@@ -252,11 +252,11 @@ const dezerializers = {
   enum: ((shape: SzEnum) => z.enum(shape.values)) as any,
 
   union: ((shape: SzUnion) =>
-    z.union(shape.options.map(dezerialize) as any)) as any,
+    z.union(shape.options.map((opt) => dezerialize(opt)) as any)) as any,
   discriminatedUnion: ((shape: SzDiscriminatedUnion) =>
     z.discriminatedUnion(
       shape.discriminator,
-      shape.options.map(dezerialize) as any
+      shape.options.map((opt) => dezerialize(opt)) as any
     )) as any,
   intersection: ((shape: SzIntersection) =>
     z.intersection(dezerialize(shape.left), dezerialize(shape.right))) as any,

--- a/src/dezerialize.ts
+++ b/src/dezerialize.ts
@@ -301,23 +301,11 @@ const dezerializers = {
       return base;
     }
     for (const { name, type } of shape.effects) {
-      if (
-        type === "refinement" &&
-        opts.superRefinements &&
-        opts.superRefinements[name]
-      ) {
+      if (type === "refinement" && opts.superRefinements?.[name]) {
         base = base.superRefine(opts.superRefinements[name]);
-      } else if (
-        type === "transform" &&
-        opts.transforms &&
-        opts.transforms[name]
-      ) {
+      } else if (type === "transform" && opts.transforms?.[name]) {
         base = base.transform(opts.transforms[name]);
-      } else if (
-        type === "preprocess" &&
-        opts.preprocesses &&
-        opts.preprocesses[name]
-      ) {
+      } else if (type === "preprocess" && opts.preprocesses?.[name]) {
         base = z.preprocess(opts.preprocesses[name], base);
       }
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -525,9 +525,11 @@ test("named superrefinements and transforms", () => {
     type: "effect",
   };
 
+  // @ts-expect-error BCE arg is deliberately bad
   const serialized = zerialize(schema, { superRefinements, transforms });
   expect(serialized).toEqual(expectedShape);
 
+  // @ts-expect-error BCE arg is deliberately bad
   const dezSchema = dezerialize(serialized, { superRefinements, transforms });
   const res1 = dezSchema.safeParse(
     new Date(new Date().getTime() + 10000000)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -461,3 +461,156 @@ test("coerce (boolean)", () => {
   });
   expect(dezerialize(shape as SzType).parse(0)).toEqual(false);
 });
+
+test("named superrefinements and transforms", () => {
+  const superRefinements = {
+    "not in future": (d: Date, ctx: z.RefinementCtx) => {
+      if (d > new Date()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          maximum: new Date().getTime(),
+          message: "Not into the future",
+          inclusive: false,
+          type: "date",
+        });
+      }
+    },
+    "far too old": (val: Date, ctx: z.RefinementCtx) => {
+      if (val < new Date("1970-01-01")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_small,
+          minimum: new Date("1970-01-01").getTime(),
+          message: "Too old",
+          inclusive: false,
+          type: "date",
+        });
+      }
+    },
+    "far too young": (val: Date, ctx: z.RefinementCtx) => {
+      if (val > new Date("2030-01-01")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          maximum: new Date("2030-01-01").getTime(),
+          message: "Too young",
+          inclusive: false,
+          type: "date",
+        });
+      }
+    },
+    BCE: (arg: Date) => arg < new Date("0001-01-01"),
+  };
+
+  const transforms = {
+    earlier: (val) => new Date(new Date().getTime() - 60000),
+  };
+
+  const schema = z
+    .date()
+    .superRefine(superRefinements["not in future"])
+    .refine(superRefinements["BCE"]) // Ignored by serialization
+    .superRefine(superRefinements["far too old"])
+    .transform(transforms.earlier)
+    .superRefine(superRefinements["far too young"]);
+
+  const expectedShape = {
+    effects: [
+      { type: "refinement", name: "not in future" },
+      { type: "refinement", name: "far too old" },
+      { type: "transform", name: "earlier" },
+      { type: "refinement", name: "far too young" },
+    ],
+    inner: {
+      type: "date",
+    },
+    type: "effect",
+  };
+
+  const serialized = zerialize(schema, { superRefinements, transforms });
+  expect(serialized).toEqual(expectedShape);
+
+  const dezSchema = dezerialize(serialized, { superRefinements, transforms });
+  const res1 = dezSchema.safeParse(
+    new Date(new Date().getTime() + 10000000)
+  ) as z.SafeParseError<Date>;
+
+  expect(res1.success).to.be.false;
+
+  const res2 = dezSchema.safeParse(
+    new Date("1969-01-01")
+  ) as z.SafeParseError<Date>;
+
+  expect(res2.success).to.be.false;
+
+  const res3 = dezSchema.safeParse(
+    new Date("2050-01-01")
+  ) as z.SafeParseError<Date>;
+
+  expect(res3.success).to.be.false;
+
+  const res4 = dezSchema.safeParse(new Date()) as z.SafeParseSuccess<Date>;
+
+  expect(res4.success).to.be.true;
+  // Will be transformed down
+  expect(res4.data.getTime()).toBeLessThan(new Date().getTime());
+});
+
+test("preprocess", () => {
+  const preprocesses = {
+    higher: (val: unknown) => (val as number) + 1000,
+  };
+
+  const schema = z.preprocess(preprocesses.higher, z.number());
+
+  const expectedShape = {
+    effects: [{ type: "preprocess", name: "higher" }],
+    inner: {
+      type: "number",
+    },
+    type: "effect",
+  };
+
+  const serialized = zerialize(schema, { preprocesses });
+  expect(serialized).toEqual(expectedShape);
+
+  const dezSchema = dezerialize(serialized, { preprocesses });
+  const res1 = dezSchema.safeParse(500) as z.SafeParseSuccess<Date>;
+
+  expect(res1.success).to.be.true;
+  expect(res1.data).to.be.equal(1500);
+});
+
+test("dezerialize effects without options", () => {
+  const superRefinements = {
+    "not in future": (d: Date, ctx: z.RefinementCtx) => {
+      if (d > new Date()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.too_big,
+          maximum: new Date().getTime(),
+          message: "Not into the future",
+          inclusive: false,
+          type: "date",
+        });
+      }
+    },
+  };
+  const schema = z.date().superRefine(superRefinements["not in future"]);
+
+  const expectedShape = {
+    effects: [{ type: "refinement", name: "not in future" }],
+    inner: {
+      type: "date",
+    },
+    type: "effect",
+  };
+
+  const serialized = zerialize(schema, { superRefinements });
+  expect(serialized).toEqual(expectedShape);
+
+  const dezSchema = dezerialize(serialized);
+
+  const res1 = dezSchema.safeParse(
+    new Date(new Date().getTime() + 10000000)
+  ) as z.SafeParseSuccess<Date>;
+
+  expect(res1.success).to.be.true;
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,15 @@ export type SzPromise<T extends SzType = SzType> = {
   value: T;
 };
 
+export type SzEffect<T extends SzType = SzType> = {
+  type: "effect";
+  effects: {
+    name: string;
+    type: "refinement" | "transform" | "preprocess";
+  }[];
+  inner: T;
+};
+
 // Modifiers
 export type SzNullable = { isNullable: boolean };
 export type SzOptional = { isOptional: boolean };
@@ -193,6 +202,7 @@ export type SzType = (
   | SzFunction<any, any>
   | SzEnum<any>
   | SzPromise<any>
+  | SzEffect<any>
 ) &
   Partial<SzNullable & SzOptional & SzDefault<any>>;
 

--- a/src/zerialize.ts
+++ b/src/zerialize.ts
@@ -131,9 +131,21 @@ type ZodTypeMap = {
 
 type ZerializerOptions =
   | {
-      superRefinements?: { [key: string]: (value: any, ctx: any) => void };
-      transforms?: { [key: string]: (value: any, ctx: any) => void };
-      preprocesses?: { [key: string]: (value: any, ctx: any) => void };
+      superRefinements?: {
+        [key: string]: (
+          value: any,
+          ctx: z.RefinementCtx
+        ) => Promise<void> | void;
+      };
+      transforms?: {
+        [key: string]: (
+          value: any,
+          ctx: z.RefinementCtx
+        ) => Promise<unknown> | unknown;
+      };
+      preprocesses?: {
+        [key: string]: (value: any, ctx: z.RefinementCtx) => unknown;
+      };
     }
   | undefined;
 

--- a/src/zerialize.ts
+++ b/src/zerialize.ts
@@ -127,16 +127,22 @@ export type Zerialize<T extends ZodTypes> =
 type ZodTypeMap = {
   [Key in ZTypeName<ZodTypes>]: Extract<ZodTypes, { _def: { typeName: Key } }>;
 };
+
+type ZerializerOptions = any;
+
 type ZerializersMap = {
-  [Key in ZTypeName<ZodTypes>]: (def: ZodTypeMap[Key]["_def"]) => any; //Zerialize<ZodTypeMap[Key]>;
+  [Key in ZTypeName<ZodTypes>]: (
+    def: ZodTypeMap[Key]["_def"],
+    opts: ZerializerOptions
+  ) => any; //Zerialize<ZodTypeMap[Key]>;
 };
 
 const s = zerialize as any;
 const zerializers = {
-  ZodOptional: (def) => ({ ...s(def.innerType), isOptional: true }),
-  ZodNullable: (def) => ({ ...s(def.innerType), isNullable: true }),
-  ZodDefault: (def) => ({
-    ...s(def.innerType),
+  ZodOptional: (def, opts) => ({ ...s(def.innerType, opts), isOptional: true }),
+  ZodNullable: (def, opts) => ({ ...s(def.innerType, opts), isNullable: true }),
+  ZodDefault: (def, opts) => ({
+    ...s(def.innerType, opts),
     defaultValue: def.defaultValue(),
   }),
 
@@ -277,24 +283,24 @@ const zerializers = {
 
   ZodLiteral: (def) => ({ type: "literal", value: def.value }),
 
-  ZodTuple: (def) => ({
+  ZodTuple: (def, opts) => ({
     type: "tuple",
-    items: def.items.map((item: ZodTypes) => s(item)),
+    items: def.items.map((item: ZodTypes) => s(item, opts)),
     ...(def.rest
       ? {
-          rest: s(def.rest),
+          rest: s(def.rest, opts),
         }
       : {}),
   }),
-  ZodSet: (def) => ({
+  ZodSet: (def, opts) => ({
     type: "set",
-    value: s(def.valueType),
+    value: s(def.valueType, opts),
     ...(def.minSize === null ? {} : { minSize: def.minSize.value }),
     ...(def.maxSize === null ? {} : { maxSize: def.maxSize.value }),
   }),
-  ZodArray: (def) => ({
+  ZodArray: (def, opts) => ({
     type: "array",
-    element: s(def.type),
+    element: s(def.type, opts),
 
     ...(def.exactLength === null
       ? {}
@@ -306,62 +312,62 @@ const zerializers = {
     ...(def.maxLength === null ? {} : { maxLength: def.maxLength.value }),
   }),
 
-  ZodObject: (def) => ({
+  ZodObject: (def, opts) => ({
     type: "object",
     properties: Object.fromEntries(
       Object.entries(def.shape()).map(([key, value]) => [
         key,
-        s(value as ZodTypes),
+        s(value as ZodTypes, opts),
       ])
     ),
   }),
-  ZodRecord: (def) => ({
+  ZodRecord: (def, opts) => ({
     type: "record",
-    key: s(def.keyType),
-    value: s(def.valueType),
+    key: s(def.keyType, opts),
+    value: s(def.valueType, opts),
   }),
-  ZodMap: (def) => ({
+  ZodMap: (def, opts) => ({
     type: "map",
-    key: s(def.keyType),
-    value: s(def.valueType),
+    key: s(def.keyType, opts),
+    value: s(def.valueType, opts),
   }),
 
   ZodEnum: (def) => ({ type: "enum", values: def.values }),
   // TODO: turn into enum
   ZodNativeEnum: () => ({ type: "unknown" }),
 
-  ZodUnion: (def) => ({
+  ZodUnion: (def, opts) => ({
     type: "union",
-    options: def.options.map((opt) => s(opt)),
+    options: def.options.map((opt) => s(opt, opts)),
   }),
-  ZodDiscriminatedUnion: (def) => ({
+  ZodDiscriminatedUnion: (def, opts) => ({
     type: "discriminatedUnion",
     discriminator: def.discriminator,
-    options: def.options.map((opt) => s(opt)),
+    options: def.options.map((opt) => s(opt, opts)),
   }),
-  ZodIntersection: (def) => ({
+  ZodIntersection: (def, opts) => ({
     type: "intersection",
-    left: s(def.left),
-    right: s(def.right),
+    left: s(def.left, opts),
+    right: s(def.right, opts),
   }),
 
-  ZodFunction: (def) => ({
+  ZodFunction: (def, opts) => ({
     type: "function",
-    args: s(def.args),
-    returns: s(def.returns),
+    args: s(def.args, opts),
+    returns: s(def.returns, opts),
   }),
-  ZodPromise: (def) => ({ type: "promise", value: s(def.type) }),
+  ZodPromise: (def, opts) => ({ type: "promise", value: s(def.type, opts) }),
 
-  ZodLazy: (def) => s(def.getter()),
-  ZodEffects: (def) => s(def.schema),
-  ZodBranded: (def) => s(def.type),
-  ZodPipeline: (def) => s(def.out),
-  ZodCatch: (def) => s(def.innerType),
+  ZodLazy: (def, opts) => s(def.getter(), opts),
+  ZodEffects: (def, opts) => s(def.schema, opts),
+  ZodBranded: (def, opts) => s(def.type, opts),
+  ZodPipeline: (def, opts) => s(def.out, opts),
+  ZodCatch: (def, opts) => s(def.innerType, opts),
 } satisfies ZerializersMap as ZerializersMap;
 
 // Must match the exported Zerialize types
 // export function zerialize<T extends ZodTypes>(_schema: T): Zerialize<T> {
-export function zerialize(schema: ZodTypes): unknown {
+export function zerialize(schema: ZodTypes, opts?: ZerializerOptions): unknown {
   const { _def: def } = schema;
-  return zerializers[def.typeName](def as any);
+  return zerializers[def.typeName](def as any, opts);
 }

--- a/src/zerialize.ts
+++ b/src/zerialize.ts
@@ -279,10 +279,10 @@ const zerializers = {
 
   ZodTuple: (def) => ({
     type: "tuple",
-    items: def.items.map(zerialize),
+    items: def.items.map((item: ZodTypes) => s(item)),
     ...(def.rest
       ? {
-          rest: zerialize(def.rest),
+          rest: s(def.rest),
         }
       : {}),
   }),
@@ -317,7 +317,7 @@ const zerializers = {
   }),
   ZodRecord: (def) => ({
     type: "record",
-    key: zerialize(def.keyType),
+    key: s(def.keyType),
     value: s(def.valueType),
   }),
   ZodMap: (def) => ({
@@ -332,31 +332,31 @@ const zerializers = {
 
   ZodUnion: (def) => ({
     type: "union",
-    options: def.options.map(s),
+    options: def.options.map((opt) => s(opt)),
   }),
   ZodDiscriminatedUnion: (def) => ({
     type: "discriminatedUnion",
     discriminator: def.discriminator,
-    options: def.options.map(zerialize),
+    options: def.options.map((opt) => s(opt)),
   }),
   ZodIntersection: (def) => ({
     type: "intersection",
     left: s(def.left),
-    right: zerialize(def.right),
+    right: s(def.right),
   }),
 
   ZodFunction: (def) => ({
     type: "function",
-    args: zerialize(def.args),
-    returns: zerialize(def.returns),
+    args: s(def.args),
+    returns: s(def.returns),
   }),
-  ZodPromise: (def) => ({ type: "promise", value: zerialize(def.type) }),
+  ZodPromise: (def) => ({ type: "promise", value: s(def.type) }),
 
-  ZodLazy: (def) => zerialize(def.getter()),
-  ZodEffects: (def) => zerialize(def.schema),
-  ZodBranded: (def) => zerialize(def.type),
-  ZodPipeline: (def) => zerialize(def.out),
-  ZodCatch: (def) => zerialize(def.innerType),
+  ZodLazy: (def) => s(def.getter()),
+  ZodEffects: (def) => s(def.schema),
+  ZodBranded: (def) => s(def.type),
+  ZodPipeline: (def) => s(def.out),
+  ZodCatch: (def) => s(def.innerType),
 } satisfies ZerializersMap as ZerializersMap;
 
 // Must match the exported Zerialize types


### PR DESCRIPTION
feat: superRefinements, transforms, preprocesses options; fixes #15

(I also uncommented the `zerialize()` signature which has a known return type if that is safe to do as seems to be the case.)