### PR TITLE
feat: update zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "type-fest": "^3.12.0",
-    "zod": "^3.22.4"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@commitlint/cli": "17.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.12.0
         version: 3.12.0
       zod:
-        specifier: ^3.22.4
-        version: 3.22.4
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@commitlint/cli':
         specifier: 17.6.5
@@ -29,7 +29,7 @@ importers:
         version: 18.2.12
       '@typescript-eslint/eslint-plugin':
         specifier: 5.59.11
-        version: 5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.43.0)(typescript@5.1.3)
+        version: 5.59.11(@typescript-eslint/parser@5.59.11(eslint@8.43.0)(typescript@5.1.3))(eslint@8.43.0)(typescript@5.1.3)
       '@typescript-eslint/parser':
         specifier: 5.59.11
         version: 5.59.11(eslint@8.43.0)(typescript@5.1.3)
@@ -2034,8 +2034,8 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
 
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
 
@@ -2120,7 +2120,7 @@ snapshots:
       '@types/node': 18.15.11
       chalk: 4.1.2
       cosmiconfig: 8.1.3
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.15.11)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.1.3)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.15.11)(cosmiconfig@8.1.3)(ts-node@10.9.1(@types/node@18.15.11)(typescript@5.1.3))(typescript@5.1.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -2417,7 +2417,7 @@ snapshots:
 
   '@types/semver@7.3.13': {}
 
-  '@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.43.0)(typescript@5.1.3)':
+  '@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11(eslint@8.43.0)(typescript@5.1.3))(eslint@8.43.0)(typescript@5.1.3)':
     dependencies:
       '@eslint-community/regexpp': 4.5.0
       '@typescript-eslint/parser': 5.59.11(eslint@8.43.0)(typescript@5.1.3)
@@ -2431,6 +2431,7 @@ snapshots:
       natural-compare-lite: 1.4.0
       semver: 7.3.8
       tsutils: 3.21.0(typescript@5.1.3)
+    optionalDependencies:
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
@@ -2442,6 +2443,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.43.0
+    optionalDependencies:
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
@@ -2458,6 +2460,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.43.0
       tsutils: 3.21.0(typescript@5.1.3)
+    optionalDependencies:
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
@@ -2473,6 +2476,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.3.8
       tsutils: 3.21.0(typescript@5.1.3)
+    optionalDependencies:
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
@@ -2767,7 +2771,7 @@ snapshots:
 
   convert-source-map@1.9.0: {}
 
-  cosmiconfig-typescript-loader@4.3.0(@types/node@18.15.11)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.1.3):
+  cosmiconfig-typescript-loader@4.3.0(@types/node@18.15.11)(cosmiconfig@8.1.3)(ts-node@10.9.1(@types/node@18.15.11)(typescript@5.1.3))(typescript@5.1.3):
     dependencies:
       '@types/node': 18.15.11
       cosmiconfig: 8.1.3
@@ -3855,12 +3859,12 @@ snapshots:
 
   vite@4.2.1(@types/node@18.15.11):
     dependencies:
-      '@types/node': 18.15.11
       esbuild: 0.17.17
       postcss: 8.4.21
       resolve: 1.22.1
       rollup: 3.20.2
     optionalDependencies:
+      '@types/node': 18.15.11
       fsevents: 2.3.2
 
   vitest@0.32.2:
@@ -3961,4 +3965,4 @@ snapshots:
 
   yocto-queue@1.0.0: {}
 
-  zod@3.22.4: {}
+  zod@3.23.8: {}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,11 +65,21 @@ test.each([
   p(z.string().url(), { type: "string", kind: "url" }),
   p(z.string().emoji(), { type: "string", kind: "emoji" }),
   p(z.string().uuid(), { type: "string", kind: "uuid" }),
+  p(z.string().nanoid(), { type: "string", kind: "nanoid" }),
   p(z.string().cuid(), { type: "string", kind: "cuid" }),
   p(z.string().cuid2(), { type: "string", kind: "cuid2" }),
   p(z.string().ulid(), { type: "string", kind: "ulid" }),
   p(z.string().ip(), { type: "string", kind: "ip" }),
   p(z.string().datetime(), { type: "string", kind: "datetime" }),
+  p(z.string().datetime({ local: true }), {
+    type: "string",
+    kind: "datetime",
+    local: true,
+  }),
+
+  p(z.string().date(), { type: "string", kind: "date" }),
+  p(z.string().duration(), { type: "string", kind: "duration" }),
+  p(z.string().base64(), { type: "string", kind: "base64" }),
 
   p(z.string().ip({ version: "v4" }), {
     type: "string",
@@ -81,6 +91,16 @@ test.each([
     type: "string",
     kind: "datetime",
     offset: true,
+    precision: 3,
+  }),
+
+  p(z.string().time(), {
+    type: "string",
+    kind: "time",
+  }),
+  p(z.string().time({ precision: 3 }), {
+    type: "string",
+    kind: "time",
     precision: 3,
   }),
 
@@ -217,7 +237,15 @@ test.each([
     properties: { foo: { type: "string" } },
   }),
 
+  p(z.object({}).readonly(), {
+    type: "object",
+    readonly: true,
+    properties: {},
+  }),
+
   p(z.literal("Gregor"), { type: "literal", value: "Gregor" }),
+
+  p(z.symbol(), { type: "symbol" }),
 
   p(z.array(z.number()), {
     type: "array",
@@ -334,7 +362,12 @@ test.each([
 test.each([
   p(z.string(), { type: "string", isOptional: false }),
   p(z.string(), { type: "string", isNullable: false }),
-])("isOptional/isNullable", (schema, shape) => {
+  p(z.object({}), {
+    type: "object",
+    readonly: false,
+    properties: {},
+  }),
+])("isOptional/isNullable/readonly", (schema, shape) => {
   expect(zerialize(dezerialize(shape) as any)).toEqual(zerialize(schema));
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,9 +26,13 @@ export const STRING_KINDS = new Set([
   "url",
   "emoji",
   "uuid",
+  "nanoid",
   "cuid",
   "cuid2",
   "ulid",
+  "date",
+  "duration",
+  "base64",
 ] as const);
 
 export type SzString = {
@@ -51,8 +55,13 @@ export type SzString = {
     | { kind: "ip"; version?: "v4" | "v6" }
     | { regex: string; flags?: string }
     | {
+        kind: "time";
+        precision?: number;
+      }
+    | {
         kind: "datetime";
         offset?: true;
+        local?: true;
         precision?: number;
       }
     | {
@@ -75,6 +84,7 @@ export type SzAny = { type: "any" };
 export type SzUnknown = { type: "unknown" };
 export type SzNever = { type: "never" };
 export type SzVoid = { type: "void" };
+export type SzSymbol = { type: "symbol" };
 
 export type SzPrimitive =
   | SzBoolean
@@ -88,7 +98,8 @@ export type SzPrimitive =
   | SzAny
   | SzUnknown
   | SzNever
-  | SzVoid;
+  | SzVoid
+  | SzSymbol;
 
 export type SzLiteral<T> = { type: "literal"; value: T };
 export type SzArray<T extends SzType = SzType> = {
@@ -183,6 +194,7 @@ export type SzNullable = { isNullable: boolean };
 export type SzOptional = { isOptional: boolean };
 export type SzDefault<T> = { defaultValue: T };
 export type SzDescription = { description: string };
+export type SzReadonly = { readonly: boolean };
 
 // Conjunctions
 export type SzKey = SzString | SzNumber;
@@ -205,7 +217,9 @@ export type SzType = (
   | SzPromise<any>
   | SzEffect<any>
 ) &
-  Partial<SzNullable & SzOptional & SzDefault<any> & SzDescription>;
+  Partial<
+    SzNullable & SzOptional & SzDefault<any> & SzDescription & SzReadonly
+  >;
 
 export type SzUnionize<T extends SzType> =
   | T

--- a/src/zod-types.ts
+++ b/src/zod-types.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 type Modifiers =
   | z.ZodOptional<ZodTypes>
   | z.ZodNullable<ZodTypes>
-  | z.ZodDefault<ZodTypes>;
+  | z.ZodDefault<ZodTypes>
+  | z.ZodReadonly<ZodTypes>;
 
 type Primitives =
   | z.ZodString
@@ -17,7 +18,8 @@ type Primitives =
   | z.ZodAny
   | z.ZodUnknown
   | z.ZodNever
-  | z.ZodVoid;
+  | z.ZodVoid
+  | z.ZodSymbol;
 
 type ListCollections =
   | z.ZodTuple<any, any>


### PR DESCRIPTION
Builds on #25 

feat: update zod

In the process:
- Adds `local` to `datetime`
- Adds `time` with `precision`
- Supports strings of type `date`, `duration`, `base64`, `nanoid`
- Supports `symbol()`
- Supports `readonly()`
