### PR TITLE
feat: add esm build

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+export default { extends: ["@commitlint/config-conventional"] };

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Zodex Demo</title>
+    <style>
+      textarea { width: 300px; height: 400px; }
+    </style>
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
+    <script type="importmap">
+      {
+        "imports": {
+          "zod": "../node_modules/zod/lib/index.mjs",
+          "react": "./react.js"
+        }
+      }
+    </script>
+    <script type="module" src="index.js"></script>
+  </head>
+  <body>
+    <textarea id="js" placeholder="Put arbitrary JavaScript object here (e.g., `{a: 5}`)">{a: 5}</textarea>
+    <textarea id="zod" placeholder="Put Zod here (e.g., `z.object({a: z.number()})`">z.object({a: z.number()})</textarea>
+    <button id="zerialize">Zerialize</button>
+    <textarea id="zodexJSON" placeholder="Put Zodex JSON here (or zerialize a Zod expression)"></textarea>
+    <button id="dezerialize">Dezerialize and validate</button>
+  </body>
+</html>

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { zerialize, dezerialize } from "../dist/esm/index.js";
+
+const $ = (sel) => {
+  return document.querySelector(sel);
+};
+
+$("#dezerialize").addEventListener("click", () => {
+  let js;
+  try {
+    js = eval(`(${$("#js").value})`);
+  } catch (err) {
+    alert("Error evaluating JavaScript");
+    return;
+  }
+
+  let json;
+  try {
+    json = JSON.parse($("#zodexJSON").value);
+  } catch (err) {
+    alert("Error evaluating JSON");
+    return;
+  }
+
+  let dez;
+  try {
+    dez = dezerialize(json);
+  } catch (err) {
+    alert("Error dezerializing JSON");
+    return;
+  }
+
+  let parseObj;
+  try {
+    parseObj = dez.safeParse(js);
+  } catch (err) {
+    alert("Error parsing JavaScript");
+    return;
+  }
+
+  alert(JSON.stringify(parseObj, null, 2));
+});
+
+$("#zerialize").addEventListener("click", () => {
+  let zod;
+  try {
+    zod = eval(`(${$("#zod").value})`);
+  } catch (err) {
+    alert("Error evaluating Zod");
+    return;
+  }
+  let zer;
+  try {
+    zer = zerialize(zod);
+  } catch (err) {
+    alert("Error zerializing Zod");
+    return;
+  }
+
+  try {
+    $("#zodexJSON").value = JSON.stringify(zer, null, 2);
+  } catch (err) {
+    alert("Error stringifying Zod JSON object");
+    return;
+  }
+});

--- a/demo/react.js
+++ b/demo/react.js
@@ -1,0 +1,1 @@
+export default {};

--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "zodex",
   "version": "0.0.0-dev",
   "description": "Type-safe (de)serialization for Zod",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "keywords": [
     "zod",
     "serialization",
@@ -13,11 +20,12 @@
   "author": "Gregor Weber<mail@dflate.io>",
   "license": "MIT",
   "scripts": {
+    "start": "vite serve demo",
     "prepare": "husky install",
     "check-style": "prettier --check src",
     "lint": "eslint src/**",
     "test": "vitest --coverage --silent=false",
-    "build": "rm -rf dist && pnpm tsc",
+    "build": "rm -rf dist && pnpm tsc --module esnext --moduleResolution bundler --outDir dist/esm && pnpm tsc && echo '{\"type\": \"commonjs\"}' > dist/package.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "prepublish": "pnpm run build"
   },
   "peerDependencies": {
@@ -44,6 +52,7 @@
     "lint-staged": "15.2.7",
     "prettier": "2.8.8",
     "typescript": "5.3.x",
+    "vite": "^5.3.1",
     "vitest": "1.6.0"
   },
   "packageManager": "pnpm@9.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: 5.3.x
         version: 5.3.3
+      vite:
+        specifier: ^5.3.1
+        version: 5.3.1(@types/node@18.15.11)
       vitest:
         specifier: 1.6.0
         version: 1.6.0(@types/node@18.15.11)

--- a/src/dezerialize.ts
+++ b/src/dezerialize.ts
@@ -32,8 +32,8 @@ import {
   SzSymbol,
   SzUnknown,
   SzVoid,
-} from "./types";
-import { ZodTypes } from "./zod-types";
+} from "./types.js";
+import { ZodTypes } from "./zod-types.js";
 
 type DezerializerOptions = {
   superRefinements?: {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { z } from "zod";
 
-import { dezerialize, SzType, zerialize, Zerialize } from "./index";
+import { dezerialize, SzType, zerialize, Zerialize } from "./index.js";
 
 const p = <
   Schema extends z.ZodFirstPartySchemaTypes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
-import { SzType } from "./types";
+import { SzType } from "./types.js";
 
-export * from "./dezerialize";
-export * from "./zerialize";
+export * from "./dezerialize.js";
+export * from "./zerialize.js";
 
-export * from "./types";
-export { mapTypesToViews } from "./ui";
+export * from "./types.js";
+export { mapTypesToViews } from "./ui.js";
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type SzPropertyKeysOf<T extends SzType> = KeysOfUnion<

--- a/src/infer.ts
+++ b/src/infer.ts
@@ -16,7 +16,7 @@ import {
   SzFunction,
   SzEnum,
   SzPromise,
-} from "./types";
+} from "./types.js";
 
 type PrimitiveTypes = {
   string: string;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { SzInfer } from "./infer";
-import { SzType } from "./types";
+import { SzInfer } from "./infer.js";
+import { SzType } from "./types.js";
 
 type ShapeValueProps<Value> = {
   value: Value;

--- a/src/zerialize.ts
+++ b/src/zerialize.ts
@@ -23,8 +23,8 @@ import {
   SzType,
   SzUnknown,
   STRING_KINDS,
-} from "./types";
-import { ZodTypes, ZTypeName } from "./zod-types";
+} from "./types.js";
+import { ZodTypes, ZTypeName } from "./zod-types.js";
 
 export const PRIMITIVES = {
   ZodString: "string",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     coverage: {
-      exclude: ["*.js", "node_modules"]
+      exclude: ["*.js", "demo", "node_modules"]
     }
   },
 });


### PR DESCRIPTION
How's this instead of #28 ?

Closes #28 .

feat: add esm build
Also:
- docs: adds demo

I left out the GitHub Pages support, so no bundling needed.