### PR TITLE
fix: export types, add .js to imports for nodenext compatibility

### DIFF
--- a/lib/dezerialize.ts
+++ b/lib/dezerialize.ts
@@ -35,11 +35,11 @@ import {
   SzVoid,
   SzRef,
   NUMBER_FORMATS,
-} from "./types";
+} from "./types.js";
 
-import { ZodTypes } from "./zod-types";
+import { ZodTypes } from "./zod-types.js";
 
-type DezerializerOptions = {
+export type DezerializerOptions = {
   errors?: {
     [key: string]: z.core.$ZodErrorMap;
   };

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import { expect, test } from "vitest";
 import { z } from "zod";
-import { SzCatch, SzEnum } from "./types";
-import { ZodTypes } from "./zod-types";
+import { SzCatch, SzEnum } from "./types.js";
+import { ZodTypes } from "./zod-types.js";
 
-import { dezerialize, SzType, zerialize, Zerialize } from "./index";
+import { dezerialize, SzType, zerialize, Zerialize } from "./index.js";
 
 const zodexSchemaJSON = JSON.parse(
   fs.readFileSync("./schema.zodex.json", "utf-8"),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ export * from "./dezerialize.js";
 export * from "./zerialize.js";
 
 export * from "./types.js";
+export * from "./zod-types.js";
 
 export type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type SzPropertyKeysOf<T extends SzType> = KeysOfUnion<

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,11 +1,11 @@
-import { SzType } from "./types";
+import { SzType } from "./types.js";
 
-export * from "./dezerialize";
-export * from "./zerialize";
+export * from "./dezerialize.js";
+export * from "./zerialize.js";
 
-export * from "./types";
+export * from "./types.js";
 
-type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type SzPropertyKeysOf<T extends SzType> = KeysOfUnion<
   Extract<T, { type: "object" }>["properties"]
 >;

--- a/lib/infer.ts
+++ b/lib/infer.ts
@@ -1,5 +1,3 @@
-import { RequiredKeysOf, OptionalKeysOf } from "type-fest";
-
 import {
   SzType,
   SzOptional,
@@ -16,7 +14,7 @@ import {
   SzEnum,
   SzPromise,
   // SzRef,
-} from "./types";
+} from "./types.js";
 
 type PrimitiveTypes = {
   string: string;

--- a/lib/zerialize.ts
+++ b/lib/zerialize.ts
@@ -30,8 +30,8 @@ import {
   SzSymbol,
   SzExtras,
   SzKey,
-} from "./types";
-import { ZodTypes, ZTypeName } from "./zod-types";
+} from "./types.js";
+import { ZodTypes, ZTypeName } from "./zod-types.js";
 
 export const PRIMITIVES = {
   ZodString: "string",
@@ -50,7 +50,7 @@ export const PRIMITIVES = {
 } as const satisfies Readonly<Partial<Record<string, SzPrimitive["type"]>>>;
 export type PrimitiveMap = typeof PRIMITIVES;
 
-type IsZodPrimitive<T extends ZodTypes> =
+export type IsZodPrimitive<T extends ZodTypes> =
   ZTypeName<T> extends keyof PrimitiveMap ? any : never;
 
 // Helper type to extract SomeType from Zod 4

--- a/lib/zod-types.ts
+++ b/lib/zod-types.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 // Helper type to extract SomeType from Zod 4
-type SomeType = z.core.SomeType;
+export type SomeType = z.core.SomeType;
 
-type Modifiers =
+export type Modifiers =
   | z.ZodOptional<SomeType>
   | z.ZodNullable<SomeType>
   | z.ZodDefault<SomeType>
@@ -13,7 +13,7 @@ type Modifiers =
   | z.ZodLazy<SomeType>
   | z.ZodReadonly<SomeType>;
 
-type Primitives =
+export type Primitives =
   | z.ZodString
   | z.ZodCoercedString
   | z.ZodNumber
@@ -33,17 +33,17 @@ type Primitives =
   | z.ZodVoid
   | z.ZodSymbol;
 
-type ListCollections =
+export type ListCollections =
   | z.ZodTuple<any, any>
   | z.ZodSet<SomeType>
   | z.ZodArray<SomeType>;
 
-type KVCollections =
+export type KVCollections =
   | z.ZodObject<any>
   | z.ZodRecord<any, SomeType>
   | z.ZodMap<SomeType, SomeType>;
 
-type ADTs =
+export type ADTs =
   | z.ZodUnion<readonly [SomeType, ...SomeType[]]>
   | z.ZodDiscriminatedUnion<readonly SomeType[]>
   | z.ZodIntersection<SomeType, SomeType>


### PR DESCRIPTION
this exports types needed to get into the internals properly, and adds .js extensions to imports so they are nodenext compatible. without them, installing this into an eg. sveltekit project will have type errors in the ide